### PR TITLE
Add uv support / inline script metadata & cleanup unused imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# Ephemeridenrechner v2  
+# Ephemeridenrechner v2
 Mit dem Ephemeridenrechner v2 für Python 3.x lassen sich Planetenpositionen und Orbits für Zeiten zwischen dem 1. Jänner 0001 und dem 31. Dezember 3000 berechnen und darstellen.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-==Ephemeridenrechner v2==  
+# Ephemeridenrechner v2  
 Mit dem Ephemeridenrechner v2 für Python 3.x lassen sich Planetenpositionen und Orbits für Zeiten zwischen dem 1. Jänner 0001 und dem 31. Dezember 3000 berechnen und darstellen.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-==Ephemeridenrechner v2==
+==Ephemeridenrechner v2==  
 Mit dem Ephemeridenrechner v2 für Python 3.x lassen sich Planetenpositionen und Orbits für Zeiten zwischen dem 1. Jänner 0001 und dem 31. Dezember 3000 berechnen und darstellen.

--- a/ephem_gui_v2.py
+++ b/ephem_gui_v2.py
@@ -5,9 +5,9 @@ import csv
 import numpy as np
 from PyQt6.QtWidgets import (
     QComboBox, QSpinBox, QApplication, QWidget, QLabel, QHBoxLayout, QVBoxLayout,
-    QPushButton, QDateTimeEdit, QTimeEdit, QSizePolicy
+    QPushButton, QTimeEdit, QSizePolicy
 )
-from PyQt6.QtCore import QDateTime, QTimer, QTime, QDate
+from PyQt6.QtCore import QTimer, QTime
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas

--- a/ephem_gui_v2.py
+++ b/ephem_gui_v2.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env -S uv run --script
+#
+# /// script
+# dependencies = [
+#   "lmfit",
+#   "matplotlib",
+#   "numpy",
+#   "PyQt6",
+# ]
+# ///
+
 import sys
 import math
 import os


### PR DESCRIPTION
This adds support for uv so that the script can either run as an executable with
```bash
chmod +x ephem_gui_v2.py
./ephem_gui_v2.py
```

or via
```bash
uv run ephem_gui_v2.py
```

All dependency installations will be automatically handled by uv thanks to [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata).

I've also removed some unused imports and changed the formatting of README.md